### PR TITLE
Selectors: Added ability to set custom item template styles

### DIFF
--- a/Selectors/Selector.xaml
+++ b/Selectors/Selector.xaml
@@ -11,6 +11,13 @@
 	Unloaded="OnUnloaded"
 	mc:Ignorable="d">
 
+	<UserControl.Resources>
+		<Style x:Key="DefaultListBoxItemStyle" TargetType="{x:Type ListBoxItem}" BasedOn="{StaticResource MaterialDesignListBoxItem}">
+			<Setter Property="HorizontalContentAlignment" Value="Left"/>
+			<Setter Property="VerticalContentAlignment" Value="Top"/>
+		</Style>
+	</UserControl.Resources>
+
 	<Grid x:Name="ContentArea">
 		<Grid.RowDefinitions>
 			<RowDefinition Height="Auto" />
@@ -61,7 +68,8 @@
 				 SelectedItem="{Binding Value}"
 				 SelectionChanged="OnSelectionChanged"
 				 VirtualizingStackPanel.IsVirtualizing="True"
-				 VirtualizingStackPanel.VirtualizationMode="Recycling">
+				 VirtualizingStackPanel.VirtualizationMode="Recycling"
+				 ItemContainerStyle="{Binding ListBoxItemStyle, FallbackValue={StaticResource DefaultListBoxItemStyle}}">
 		</ListBox>
 
 		<ProgressBar

--- a/Selectors/Selector.xaml.cs
+++ b/Selectors/Selector.xaml.cs
@@ -3,6 +3,8 @@
 
 namespace XivToolsWpf.Selectors;
 
+using PropertyChanged;
+using Serilog;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -14,8 +16,6 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
-using PropertyChanged;
-using Serilog;
 using XivToolsWpf;
 
 /// <summary>
@@ -26,6 +26,7 @@ public partial class Selector : UserControl, INotifyPropertyChanged
 {
 	public static readonly DependencyProperty ValueProperty = DependencyProperty.Register(nameof(Value), typeof(object), typeof(Selector), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnValueChangedStatic)));
 	public static readonly DependencyProperty ItemTemplateProperty = DependencyProperty.Register(nameof(ItemTemplate), typeof(DataTemplate), typeof(Selector), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnValueChangedStatic)));
+	public static readonly DependencyProperty ListBoxItemStyleProperty = DependencyProperty.Register(nameof(ListBoxItemStyle), typeof(Style), typeof(Selector), new FrameworkPropertyMetadata(new PropertyChangedCallback(OnValueChangedStatic)));
 
 	private static readonly Dictionary<Type, string?> SearchInputs = new Dictionary<Type, string?>();
 	private static readonly Dictionary<Type, double> ScrollPositions = new Dictionary<Type, double>();
@@ -86,6 +87,12 @@ public partial class Selector : UserControl, INotifyPropertyChanged
 	{
 		get => (DataTemplate)this.GetValue(ItemTemplateProperty);
 		set => this.SetValue(ItemTemplateProperty, value);
+	}
+
+	public Style ListBoxItemStyle
+	{
+		get => (Style)this.GetValue(ListBoxItemStyleProperty);
+		set => this.SetValue(ListBoxItemStyleProperty, value);
 	}
 
 	public double ScrollPosition


### PR DESCRIPTION
This pull request is part of my efforts to resolve most of the XAML binding errors plaguing Anamnesis.

These changes will allow all classes that inherit the Selector base class to be able to set their own item style if they so desire. Otherwise, the selector will set the item style to fallback default style.

The XAML binding errors that will be resolved are as follows:
> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=HorizontalContentAlignment; DataItem=null; target element is 'ListBoxItem' (Name=''); target property is 'HorizontalContentAlignment' (type 'HorizontalAlignment')

> System.Windows.Data Error: 4 : Cannot find source for binding with reference 'RelativeSource FindAncestor, AncestorType='System.Windows.Controls.ItemsControl', AncestorLevel='1''. BindingExpression:Path=VerticalContentAlignment; DataItem=null; target element is 'ListBoxItem' (Name=''); target property is 'VerticalContentAlignment' (type 'VerticalAlignment')

The root cause of the XAML binding errors is the MaterialDesignListBoxItem style, which expects both HorizontalContentAlignment and VerticalContentAlignment to be set:
- https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/31659beec642b0519d7607cc1dfa6f6a99a66615/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml#L246
- https://github.com/MaterialDesignInXAML/MaterialDesignInXamlToolkit/blob/31659beec642b0519d7607cc1dfa6f6a99a66615/src/MaterialDesignThemes.Wpf/Themes/MaterialDesignTheme.ListBox.xaml#L341
