### PR TITLE
Resolved issue with Vector2 conversion from string

### DIFF
--- a/Math3D/Extensions/VectorExtensions.cs
+++ b/Math3D/Extensions/VectorExtensions.cs
@@ -96,7 +96,7 @@ public static class VectorExtensions
 	{
 		string[] parts = str.Split(new[] { ", " }, StringSplitOptions.RemoveEmptyEntries);
 
-		if (parts.Length != 3)
+		if (parts.Length != 2)
 			throw new FormatException();
 
 		Vector2 v = default;


### PR DESCRIPTION
Typo in the validation. It was checking for 3 elements "X, Y, Z" but for Vector 2 its just "X, Y".