### PR TITLE
Fixed virtualization of selector user control

### DIFF
--- a/Behaviours/Behaviour.cs
+++ b/Behaviours/Behaviour.cs
@@ -9,6 +9,7 @@ using System.Windows;
 public abstract class Behaviour : IDisposable
 {
 	public readonly DependencyObject Host;
+	private bool disposed = false;
 
 	public Behaviour(DependencyObject host)
 	{
@@ -35,6 +36,20 @@ public abstract class Behaviour : IDisposable
 
 	public virtual void Dispose()
 	{
+		if (this.disposed)
+			return;
+
+		if (this.Host is FrameworkElement frameworkElement)
+		{
+			frameworkElement.Loaded -= this.OnSelfLoaded;
+		}
+		else if (this.Host is FrameworkContentElement frameworkContentElement)
+		{
+			frameworkContentElement.Loaded -= this.OnSelfLoaded;
+		}
+
+		disposed = true;
+		GC.SuppressFinalize(this);
 	}
 
 	private void OnSelfLoaded(object sender, RoutedEventArgs e)

--- a/DragAndDrop/DropTargetAdorner.cs
+++ b/DragAndDrop/DropTargetAdorner.cs
@@ -3,8 +3,8 @@
 
 namespace XivToolsWpf.DragAndDrop;
 
-using System.Windows.Documents;
 using System.Windows;
+using System.Windows.Documents;
 using System.Windows.Media;
 
 public abstract class DropTargetAdorner : Adorner
@@ -22,7 +22,7 @@ public abstract class DropTargetAdorner : Adorner
 
 	public DragEventArgs EventArgs { get; private set; }
 
-	public void Detatch()
+	public void Detach()
 	{
 		this.adornerLayer?.Remove(this);
 	}

--- a/Selectors/Selector.xaml
+++ b/Selectors/Selector.xaml
@@ -63,7 +63,7 @@
 				 Grid.Row="1"
 				 HorizontalContentAlignment="Stretch"
 				 ItemTemplate="{Binding ItemTemplate}"
-				 ItemsSource="{Binding FilteredItems}"
+				 ItemsSource="{Binding FilteredItems.View}"
 				 MouseDoubleClick="OnDoubleClick"
 				 SelectedItem="{Binding Value}"
 				 SelectionChanged="OnSelectionChanged"


### PR DESCRIPTION
The issue that put pressure on the garbage collector was caused by incorrect virtualization of the selector's listbox. As a result, C# generated data bindings for all items in the selector, regardless if they were visible or not. To address this, the observable collection of the filtered items member variable has been replaced with a collection view source. 

The images below illustrate memory allocation deltas between two snapshots of the memory usage of approximately equal duration and actions taken.

**Before:**
![image](https://github.com/user-attachments/assets/47b2a418-dc82-4b28-a423-d41419b5f5f1)

**After:**
![image](https://github.com/user-attachments/assets/58328af5-b844-4102-b527-f8d949bf79da)

---

**Other changes:**
- Cleanup of the selector class.
- Added proper disposal of behaviour and reorderable components.
- Fixed mistyped method name.