### PR TITLE
Theme adjustments and various theme-handling fixes

### DIFF
--- a/Controls/NumberBox.xaml.cs
+++ b/Controls/NumberBox.xaml.cs
@@ -3,15 +3,14 @@
 
 namespace XivToolsWpf.Controls;
 
+using PropertyChanged;
 using System;
 using System.ComponentModel;
 using System.Data;
-using System.Drawing;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
-using PropertyChanged;
 using XivToolsWpf.DependencyProperties;
 using DrawPoint = System.Drawing.Point;
 using WinCur = System.Windows.Forms.Cursor;
@@ -307,6 +306,7 @@ public partial class NumberBox : UserControl, INotifyPropertyChanged
 	{
 		bool v = mode != SliderModes.None;
 
+		sender.InputSlider.IsMoveToPointEnabled = mode == SliderModes.Absolute;
 		sender.SliderArea.Width = v ? new GridLength(1, GridUnitType.Star) : new GridLength(0);
 		sender.InputBoxArea.Width = v ? new GridLength(42) : new GridLength(1, GridUnitType.Star);
 

--- a/Styles/BorderStyles.xaml
+++ b/Styles/BorderStyles.xaml
@@ -2,7 +2,7 @@
 					xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 	
 	<Style x:Key="Panel" TargetType="{x:Type Border}">
-		<Setter Property="Background" Value="#11FFFFFF"/>
+		<Setter Property="Background" Value="{DynamicResource PanelBackgroundBrush}"/>
 		<Setter Property="BorderThickness" Value="1"/>
 		<Setter Property="SnapsToDevicePixels" Value="True"/>
 		<Setter Property="BorderBrush" Value="#11000000"/>

--- a/Styles/WindowStyles.xaml
+++ b/Styles/WindowStyles.xaml
@@ -6,21 +6,22 @@
 				<ControlTemplate TargetType="{x:Type Window}">
 					<Grid>
 						<Grid>
-
 							<Grid.RowDefinitions>
-								<RowDefinition Height="27"/>
+								<RowDefinition Height="26"/>
 								<RowDefinition/>
 							</Grid.RowDefinitions>
-							
+
 							<Rectangle Grid.Row="0" Fill="Transparent" x:Name="TitleBarArea"/>
 							<Rectangle Grid.Row="1" Fill="{DynamicResource MaterialDesignPaper}" x:Name="BackgroundArea"/>
 						</Grid>
 
 						<ContentPresenter Content="{TemplateBinding Content}"/>
-
 					</Grid>
 				</ControlTemplate>
 			</Setter.Value>
 		</Setter>
+		<Setter Property="UseLayoutRounding" Value="True"/>
+		<Setter Property="SnapsToDevicePixels" Value="True"/>
+		<Setter Property="OverridesDefaultStyle" Value="True"/>
 	</Style>
 </ResourceDictionary>

--- a/Styles/WindowStyles.xaml
+++ b/Styles/WindowStyles.xaml
@@ -11,8 +11,8 @@
 								<RowDefinition/>
 							</Grid.RowDefinitions>
 
-							<Rectangle Grid.Row="0" Fill="Transparent" x:Name="TitleBarArea"/>
-							<Rectangle Grid.Row="1" Fill="{DynamicResource MaterialDesignPaper}" x:Name="BackgroundArea"/>
+							<Rectangle Grid.Row="0" Fill="Transparent" x:Name="TitleBarArea" IsHitTestVisible="False"/>
+							<Rectangle Grid.Row="1" Fill="{DynamicResource MaterialDesignPaper}" x:Name="BackgroundArea" IsHitTestVisible="False"/>
 						</Grid>
 
 						<ContentPresenter Content="{TemplateBinding Content}"/>

--- a/Themes.cs
+++ b/Themes.cs
@@ -3,13 +3,10 @@
 
 namespace XivToolsWpf;
 
-using System;
-using System.Threading.Tasks;
-using System.Windows;
-using System.Windows.Media;
-using MaterialDesignColors;
 using MaterialDesignThemes.Wpf;
 using Microsoft.Win32;
+using System.Windows;
+using System.Windows.Media;
 
 public static class Themes
 {
@@ -21,6 +18,8 @@ public static class Themes
 		SystemParameters.StaticPropertyChanged += OnSystemParametersChanged;
 	}
 
+	public static bool IsLightTheme => currentLight;
+
 	public static void ApplyCustomTheme(bool light, Color highlightColor)
 	{
 		if (currentColor == highlightColor && currentLight == light)
@@ -29,8 +28,28 @@ public static class Themes
 		currentColor = highlightColor;
 		currentLight = light;
 
-		Theme theme = new Theme();
-		theme.SetBaseTheme(light ? new LightTheme() : new DarkTheme());
+		var theme = new Theme();
+
+		if (light)
+		{
+			var lightTheme = new LightTheme();
+			theme.SetBaseTheme(lightTheme);
+
+			// Custom theme properties (Extension from material design base theme)
+			Application.Current.Resources["PanelBackground"] = lightTheme.PanelBackground;
+			Application.Current.Resources["PanelBackgroundBrush"] = new SolidColorBrush(lightTheme.PanelBackground);
+
+		}
+		else
+		{
+			var darkTheme = new DarkTheme();
+			theme.SetBaseTheme(darkTheme);
+
+			// Custom theme properties (Extension from material design base theme)
+			Application.Current.Resources["PanelBackground"] = darkTheme.PanelBackground;
+			Application.Current.Resources["PanelBackgroundBrush"] = new SolidColorBrush(darkTheme.PanelBackground);
+		}
+
 		theme.SetPrimaryColor(currentColor);
 		////theme.SetSecondaryColor(currentColor);
 
@@ -84,6 +103,7 @@ public static class Themes
 		public Color MaterialDesignTextAreaBorder { get; } = (Color)ColorConverter.ConvertFromString("#BCFFFFFF");
 		public Color MaterialDesignTextAreaInactiveBorder { get; } = (Color)ColorConverter.ConvertFromString("#29FFFFFF");
 		public Color MaterialDesignDataGridRowHoverBackground { get; } = (Color)ColorConverter.ConvertFromString("#14FFFFFF");
+		public Color PanelBackground { get; } = (Color)ColorConverter.ConvertFromString("#11FFFFFF");
 	}
 
 	public class LightTheme : IBaseTheme
@@ -94,7 +114,7 @@ public static class Themes
 		public Color MaterialDesignCardBackground { get; } = (Color)ColorConverter.ConvertFromString("#FFFFFFFF");
 		public Color MaterialDesignToolBarBackground { get; } = (Color)ColorConverter.ConvertFromString("#FFF5F5F5");
 		public Color MaterialDesignBody { get; } = (Color)ColorConverter.ConvertFromString("#DD000000");
-		public Color MaterialDesignBodyLight { get; } = (Color)ColorConverter.ConvertFromString("#89000000");
+		public Color MaterialDesignBodyLight { get; } = (Color)ColorConverter.ConvertFromString("#DD000000");
 		public Color MaterialDesignColumnHeader { get; } = (Color)ColorConverter.ConvertFromString("#BC000000");
 		public Color MaterialDesignCheckBoxOff { get; } = (Color)ColorConverter.ConvertFromString("#89000000");
 		public Color MaterialDesignCheckBoxDisabled { get; } = (Color)ColorConverter.ConvertFromString("#FFBDBDBD");
@@ -116,5 +136,6 @@ public static class Themes
 		public Color MaterialDesignTextAreaBorder { get; } = (Color)ColorConverter.ConvertFromString("#BC000000");
 		public Color MaterialDesignTextAreaInactiveBorder { get; } = (Color)ColorConverter.ConvertFromString("#29000000");
 		public Color MaterialDesignDataGridRowHoverBackground { get; } = (Color)ColorConverter.ConvertFromString("#0A000000");
+		public Color PanelBackground { get; } = (Color)ColorConverter.ConvertFromString("#55FFFFFF");
 	}
 }

--- a/Themes.cs
+++ b/Themes.cs
@@ -12,6 +12,7 @@ public static class Themes
 {
 	private static Color currentColor;
 	private static bool currentLight;
+	private static int? prevThemeRegKey = null;
 
 	static Themes()
 	{
@@ -58,13 +59,17 @@ public static class Themes
 
 	public static void ApplySystemTheme()
 	{
-		int? value = Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize\\", "AppsUseLightTheme", 0) as int?;
+		int? currentValue = Registry.GetValue("HKEY_CURRENT_USER\\Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize\\", "AppsUseLightTheme", 0) as int?;
 
-		if (value != null)
+		if (currentValue != prevThemeRegKey)
 		{
-			bool lightMode = value == 1;
+			prevThemeRegKey = currentValue;
 
-			ApplyCustomTheme(lightMode, SystemParameters.WindowGlassColor);
+			if (currentValue != null)
+			{
+				bool lightMode = currentValue == 1;
+				ApplyCustomTheme(lightMode, SystemParameters.WindowGlassColor);
+			}
 		}
 	}
 

--- a/Utility/Win32.cs
+++ b/Utility/Win32.cs
@@ -7,9 +7,14 @@ namespace XivToolsWpf.Utility;
 
 using System;
 using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
 
 public static partial class Win32
 {
+	private const int WM_NCPAINT = 0x0085;
+	private const int WM_NCACTIVATE = 0x0086;
+
 	public static readonly IntPtr InvisibleRegion = CreateRectRgn(0, 0, -1, -1);
 
 	public enum AccentState
@@ -222,8 +227,18 @@ public static partial class Win32
 		}
 	}
 
+	public static void RedrawNonClientArea(Window window)
+	{
+		var hwnd = new WindowInteropHelper(window).Handle;
+		_ = SendMessage(hwnd, WM_NCPAINT, IntPtr.Zero, IntPtr.Zero);
+		_ = SendMessage(hwnd, WM_NCACTIVATE, window.IsActive ? 1 : 0, IntPtr.Zero);
+	}
+
 	[LibraryImport("user32.dll")]
 	private static partial int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+
+	[LibraryImport("user32.dll", EntryPoint = "SendMessageA")]
+	private static partial IntPtr SendMessage(IntPtr hWnd, int msg, IntPtr wParam, IntPtr lParam);
 
 	[LibraryImport("dwmapi.dll")]
 	private static partial void DwmEnableBlurBehindWindow(IntPtr hwnd, ref DWM_BLURBEHIND blurBehind);

--- a/Utility/Win32.cs
+++ b/Utility/Win32.cs
@@ -1,0 +1,236 @@
+﻿// © XIV-Tools.
+// Licensed under the MIT license.
+
+[assembly: System.Runtime.CompilerServices.DisableRuntimeMarshalling]
+
+namespace XivToolsWpf.Utility;
+
+using System;
+using System.Runtime.InteropServices;
+
+public static partial class Win32
+{
+	public static readonly IntPtr InvisibleRegion = CreateRectRgn(0, 0, -1, -1);
+
+	public enum AccentState
+	{
+		ACCENT_DISABLED = 0,
+		ACCENT_ENABLE_GRADIENT = 1,
+		ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
+		ACCENT_ENABLE_BLURBEHIND = 3,
+		ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
+		ACCENT_INVALID_STATE = 5,
+	}
+
+	/// <summary>
+	/// Options used by the WINDOWCOMPOSITIONATTRIBDATA structure.
+	/// Used with the GetWindowCompositionAttribute and SetWindowCompositionAttribute functions.
+	/// </summary>
+	/// <remarks>
+	/// Source: https://learn.microsoft.com/en-us/windows/win32/dwm/windowcompositionattribdata
+	/// </remarks>
+	public enum WindowCompositionAttribute
+	{
+		WCA_ACCENT_POLICY = 19,
+		WCA_USEDARKMODECOLORS = 26,
+	}
+
+	/// <summary>
+	/// Flags for the DWM_BLURBEHIND structure.
+	/// </summary>
+	/// <remarks>
+	/// Source: https://learn.microsoft.com/en-us/windows/win32/dwm/dwm-bb-constants
+	/// </remarks>
+	public enum DwmBlurBehindFlags : int
+	{
+		DWM_BB_ENABLE = 0x00000001,
+		DWM_BB_BLURREGION = 0x00000002,
+		DWM_BB_TRANSITIONONMAXIMIZED = 0x00000004,
+	}
+
+	/// <summary>
+	/// Flags for specyfing the system-drawn backdrop material of a window, including the non-client area.
+	/// </summary>
+	/// <remarks>
+	/// Source: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwm_systembackdrop_type
+	/// </remarks>
+	public enum DwmSystemBackdropType : uint
+	{
+		/// <summary>Automatic (Default)</summary>
+		DWMSBT_AUTO,
+
+		/// <summary>No Backdrop</summary>
+		DWMSBT_NONE,
+
+		/// <summary>Mica</summary>
+		DWMSBT_MAINWINDOW,
+
+		/// <summary>Acrylic</summary>
+		DWMSBT_TRANSIENTWINDOW,
+
+		/// <summary>Mica Alt</summary>
+		DWMSBT_TABBEDWINDOW,
+	}
+
+	/// <summary>
+	/// Options used by the DwmSetWindowAttribute and DwmSetWindowAttribute functions.
+	/// </summary>
+	/// <remarks>
+	/// Source: https://learn.microsoft.com/en-us/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+	/// </remarks>
+	public enum DwmWindowAttribute : int
+	{
+		/// <summary>
+		/// Specifies the colorization color of the window frame.
+		/// </summary>
+		/// <remarks>
+		/// For versions prior to Windows 10 20H1 (Build 19041).
+		/// </remarks>
+		DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1 = 19,
+
+		/// <summary>
+		/// Specifies the colorization color of the window frame.
+		/// Whenever set to true, dark mode will be honored. Otherwise, light mode will be used.
+		/// </summary>
+		/// <remarks>
+		/// Supported starting Windows 11 Build 22000.
+		/// </remarks>
+		DWMWA_USE_IMMERSIVE_DARK_MODE = 20,
+
+		/// <summary>
+		/// Specifies the color of the window caption (i.e., the title bar)
+		/// </summary>
+		/// <remarks>
+		/// Supported starting Windows 11 Build 22000.
+		/// </remarks>
+		DWMWA_CAPTION_COLOR = 35,
+
+		/// <summary>
+		/// Specifies the system-drawn backdrop material of a window, including the non-client area.
+		/// </summary>
+		/// <remarks>
+		/// Supported starting Windows 11 Build 22621.
+		/// </remarks>
+		DWMWA_SYSTEMBACKDROP_TYPE = 38,
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct AccentPolicy
+	{
+		public AccentState AccentState;
+		public uint AccentFlags;
+		public uint GradientColor;
+		public uint AnimationId;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct WindowCompositionAttributeData
+	{
+		public WindowCompositionAttribute Attribute;
+		public IntPtr Data;
+		public int SizeOfData;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	public struct DWM_BLURBEHIND
+	{
+		public int Flags;
+
+		[MarshalAs(UnmanagedType.Bool)]
+		public bool Enable;
+
+		public IntPtr RgnBlur;
+
+		[MarshalAs(UnmanagedType.Bool)]
+		public bool TransitionOnMaximized;
+	}
+
+	public static bool IsWindows11() => Environment.OSVersion.Version.Major == 10 && Environment.OSVersion.Version.Build >= 22000;
+	public static bool IsWindows10() => Environment.OSVersion.Version.Major == 10 && Environment.OSVersion.Version.Build < 22000;
+
+	public static void SetWindowDarkMode(nint windowHandle, bool darkMode)
+	{
+		bool isWindows11 = IsWindows11();
+		bool isWindows10 = IsWindows10();
+
+		if (isWindows11)
+		{
+			// Set titlebar color (Windows 11 Build 22000 and higher)
+			// Note: This affects the caption control button foreground as well.
+			uint colorPvAttribute = darkMode ? (uint)0x303030 : (uint)0xFAFAFA;
+			_ = DwmSetWindowAttribute(windowHandle, (int)DwmWindowAttribute.DWMWA_CAPTION_COLOR, ref colorPvAttribute, sizeof(uint));
+		}
+
+		if (isWindows10 || isWindows11)
+		{
+			int dwmAttribute = (int)DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE;
+			if (Environment.OSVersion.Version.Build < 19041)
+				dwmAttribute = (int)DwmWindowAttribute.DWMWA_USE_IMMERSIVE_DARK_MODE_BEFORE_20H1;
+
+			// Set immersive dark mode
+			uint useImmersiveDarkMode = darkMode ? 1u : 0u;
+			_ = DwmSetWindowAttribute(windowHandle, dwmAttribute, ref useImmersiveDarkMode, sizeof(uint));
+		}
+
+		unsafe
+		{
+			int darkModeAttribute = darkMode ? 1 : 0;
+			WindowCompositionAttributeData data = new()
+			{
+				Attribute = WindowCompositionAttribute.WCA_USEDARKMODECOLORS,
+				SizeOfData = sizeof(int),
+				Data = (IntPtr)(&darkModeAttribute),
+			};
+
+			_ = SetWindowCompositionAttribute(windowHandle, ref data);
+		}
+	}
+
+	public static void SetBlurBehindWindow(IntPtr hwnd, bool enable)
+	{
+		DWM_BLURBEHIND blurBehind = new()
+		{
+			Flags = (int)DwmBlurBehindFlags.DWM_BB_ENABLE | (int)DwmBlurBehindFlags.DWM_BB_BLURREGION,
+			Enable = enable,
+			RgnBlur = enable ? InvisibleRegion : IntPtr.Zero,
+		};
+
+		DwmEnableBlurBehindWindow(hwnd, ref blurBehind);
+	}
+
+	public static void SetAccentPolicy(IntPtr hwnd, AccentPolicy accentPolicy)
+	{
+		unsafe
+		{
+			WindowCompositionAttributeData data = new()
+			{
+				Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY,
+				SizeOfData = sizeof(AccentPolicy),
+				Data = (IntPtr)(&accentPolicy),
+			};
+
+			_ = SetWindowCompositionAttribute(hwnd, ref data);
+		}
+	}
+
+	public static void SetSystemBackdropType(IntPtr hwnd, DwmSystemBackdropType backdropType)
+	{
+		if (Environment.OSVersion.Version.Build >= 22621)
+		{
+			uint backdropTypeValue = (uint)backdropType;
+			_ = DwmSetWindowAttribute(hwnd, (int)DwmWindowAttribute.DWMWA_SYSTEMBACKDROP_TYPE, ref backdropTypeValue, sizeof(uint));
+		}
+	}
+
+	[LibraryImport("user32.dll")]
+	private static partial int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
+
+	[LibraryImport("dwmapi.dll")]
+	private static partial void DwmEnableBlurBehindWindow(IntPtr hwnd, ref DWM_BLURBEHIND blurBehind);
+
+	[LibraryImport("gdi32.dll")]
+	private static partial IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
+
+	[LibraryImport("dwmapi.dll")]
+	private static partial int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, ref uint pvAttribute, int cbAttribute);
+}

--- a/Windows/ChromedWindow.cs
+++ b/Windows/ChromedWindow.cs
@@ -109,6 +109,7 @@ public class ChromedWindow : Window
 		this.SetTranslucency();
 
 		// Force a redraw
+		Win32.RedrawNonClientArea(this);
 		this.InvalidateVisual();
 		this.UpdateLayout();
 	}

--- a/Windows/ChromedWindow.cs
+++ b/Windows/ChromedWindow.cs
@@ -50,6 +50,7 @@ public class ChromedWindow : Window
 	}
 
 	public bool TransprentWhenNotInFocus { get; set; }
+	public double WindowOpacity { get; set; }
 
 	public bool ExtendIntoChrome
 	{
@@ -164,7 +165,7 @@ public class ChromedWindow : Window
 		if (this.TransprentWhenNotInFocus && !this.IsActive)
 		{
 			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
-			blurOpacity = 0;
+			blurOpacity = (int)Math.Clamp(255 * this.WindowOpacity, 0, 255);
 			blurBackgroundColor = this.isDarkTheme ? 0x303030 : 0xFFFFFF;
 		}
 		else if (!this.EnableTranslucency || (!isWindows10 && !isWindows11))

--- a/Windows/ChromedWindow.cs
+++ b/Windows/ChromedWindow.cs
@@ -20,6 +20,7 @@ public class ChromedWindow : Window
 	private bool enableTranslucency = true;
 	private bool isDarkTheme = false;
 	private bool extendIntoChrome = true;
+	private bool prevBlurStatus = false;
 
 	public ChromedWindow()
 	{
@@ -168,6 +169,7 @@ public class ChromedWindow : Window
 			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
 			blurOpacity = (int)Math.Clamp(255 * this.WindowOpacity, 0, 255);
 			blurBackgroundColor = this.isDarkTheme ? 0x303030 : 0xFFFFFF;
+			enableBlurEffect = this.EnableTranslucency && (isWindows10 || isWindows11);
 		}
 		else if (!this.EnableTranslucency || (!isWindows10 && !isWindows11))
 		{
@@ -208,6 +210,10 @@ public class ChromedWindow : Window
 
 		Win32.SetAccentPolicy(windowHelper.Handle, accent);
 
-		Win32.SetBlurBehindWindow(windowHelper.Handle, enableBlurEffect);
+		if (enableBlurEffect != this.prevBlurStatus)
+		{
+			this.prevBlurStatus = enableBlurEffect;
+			Win32.SetBlurBehindWindow(windowHelper.Handle, enableBlurEffect);
+		}
 	}
 }

--- a/Windows/ChromedWindow.cs
+++ b/Windows/ChromedWindow.cs
@@ -3,23 +3,20 @@
 
 namespace XivToolsWpf.Windows;
 
+using MaterialDesignThemes.Wpf;
+using PropertyChanged;
 using System;
-using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
 using System.Windows.Shapes;
 using System.Windows.Shell;
-using MaterialDesignThemes.Wpf;
-using PropertyChanged;
+using XivToolsWpf.Utility;
 
 [AddINotifyPropertyChangedInterface]
 public class ChromedWindow : Window
 {
-	private static readonly IntPtr InvisibleRegion = CreateRectRgn(0, 0, -1, -1);
-
 	private bool enableTranslucency = true;
 	private bool isDarkTheme = false;
 	private bool extendIntoChrome = true;
@@ -35,29 +32,11 @@ public class ChromedWindow : Window
 		this.MouseDown += this.OnMouseDown;
 		this.Loaded += this.OnLoaded;
 
-		this.TitlebarForeground = new SolidColorBrush(Colors.Black);
-
 		IThemeManager? themeManager = new PaletteHelper().GetThemeManager();
 		if (themeManager != null)
 		{
 			themeManager.ThemeChanged += this.OnThemeChanged;
 		}
-	}
-
-	private enum AccentState
-	{
-		ACCENT_DISABLED = 0,
-		ACCENT_ENABLE_GRADIENT = 1,
-		ACCENT_ENABLE_TRANSPARENTGRADIENT = 2,
-		ACCENT_ENABLE_BLURBEHIND = 3,
-		ACCENT_ENABLE_ACRYLICBLURBEHIND = 4,
-		ACCENT_INVALID_STATE = 5,
-	}
-
-	private enum WindowCompositionAttribute
-	{
-		WCA_ACCENT_POLICY = 19,
-		WCA_USEDARKMODECOLORS = 26,
 	}
 
 	public bool EnableTranslucency
@@ -70,17 +49,7 @@ public class ChromedWindow : Window
 		}
 	}
 
-	public Brush TitlebarForeground
-	{
-		get;
-		set;
-	}
-
-	public bool TransprentWhenNotInFocus
-	{
-		get;
-		set;
-	}
+	public bool TransprentWhenNotInFocus { get; set; }
 
 	public bool ExtendIntoChrome
 	{
@@ -92,43 +61,19 @@ public class ChromedWindow : Window
 		}
 	}
 
-	public bool GetIsActive()
-	{
-		return WindowExtensions.GetIsActive(this);
-	}
+	public bool GetIsActive() => WindowExtensions.GetIsActive(this);
 
 	protected override void OnActivated(EventArgs e)
 	{
-		if (!this.EnableTranslucency || this.isDarkTheme)
-		{
-			this.TitlebarForeground = new SolidColorBrush(Colors.White);
-		}
-		else if (!this.isDarkTheme)
-		{
-			this.TitlebarForeground = new SolidColorBrush(Colors.Black);
-		}
-
 		base.OnActivated(e);
 		this.SetTranslucency();
 	}
 
 	protected override void OnDeactivated(EventArgs e)
 	{
-		if (!this.EnableTranslucency)
-			this.TitlebarForeground = new SolidColorBrush(Colors.DarkGray);
-
 		base.OnDeactivated(e);
 		this.SetTranslucency();
 	}
-
-	[DllImport("user32.dll")]
-	private static extern int SetWindowCompositionAttribute(IntPtr hwnd, ref WindowCompositionAttributeData data);
-
-	[DllImport("dwmapi.dll")]
-	private static extern void DwmEnableBlurBehindWindow(IntPtr hwnd, ref DWM_BLURBEHIND blurBehind);
-
-	[DllImport("gdi32.dll")]
-	private static extern IntPtr CreateRectRgn(int x1, int y1, int x2, int y2);
 
 	private void OnLoaded(object sender, RoutedEventArgs e)
 	{
@@ -161,6 +106,10 @@ public class ChromedWindow : Window
 	{
 		this.SetChrome();
 		this.SetTranslucency();
+
+		// Force a redraw
+		this.InvalidateVisual();
+		this.UpdateLayout();
 	}
 
 	private void SetChrome()
@@ -177,11 +126,13 @@ public class ChromedWindow : Window
 		{
 			chrome.NonClientFrameEdges = NonClientFrameEdges.Right | NonClientFrameEdges.Left | NonClientFrameEdges.Bottom;
 			chrome.CaptionHeight = 0;
+			chrome.GlassFrameThickness = new Thickness(-1);
 		}
 		else
 		{
 			chrome.NonClientFrameEdges = NonClientFrameEdges.None;
 			chrome.CaptionHeight = 22;
+			chrome.GlassFrameThickness = default;
 			chrome.UseAeroCaptionButtons = true;
 		}
 	}
@@ -191,41 +142,34 @@ public class ChromedWindow : Window
 		if (!this.ExtendIntoChrome)
 			this.enableTranslucency = false;
 
-		Rectangle? titlebarRect = this.GetTemplateChild("TitleBarArea") as Rectangle;
-		Rectangle? backgroundRect = this.GetTemplateChild("BackgroundArea") as Rectangle;
-
-		if (titlebarRect == null || backgroundRect == null)
+		if (this.GetTemplateChild("TitleBarArea") is not Rectangle titlebarRect ||
+			this.GetTemplateChild("BackgroundArea") is not Rectangle backgroundRect)
 			return;
 
-		WindowInteropHelper? windowHelper = new WindowInteropHelper(this);
-
-		AccentPolicy accent = new();
-
-		DWM_BLURBEHIND blurBehind = new();
-		blurBehind.Flags = /* DWM_BB_ENABLE | DWM_BB_BLUREGION */ 0x1 | 0x2;
-		blurBehind.Enable = false;
-		blurBehind.RgnBlur = IntPtr.Zero;
+		WindowInteropHelper? windowHelper = new(this);
+		bool enableBlurEffect = false;
 
 		this.isDarkTheme = new PaletteHelper().GetTheme().GetBaseTheme() == BaseTheme.Dark;
+
+		Win32.SetWindowDarkMode(windowHelper.Handle, this.isDarkTheme);
 
 		int blurOpacity = 0;
 		int blurBackgroundColor = 0x000000;
 
-		bool isWindows11 = RuntimeInformation.OSDescription.StartsWith("Microsoft Windows 10.0.2");
-		bool isWindows10 = false;
+		bool isWindows11 = Win32.IsWindows11();
+		bool isWindows10 = Win32.IsWindows10();
 
-		if (!isWindows11)
-			isWindows10 = RuntimeInformation.OSDescription.StartsWith("Microsoft Windows 10");
+		var accent = new Win32.AccentPolicy();
 
 		if (this.TransprentWhenNotInFocus && !this.IsActive)
 		{
-			accent.AccentState = AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
+			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_TRANSPARENTGRADIENT;
 			blurOpacity = 0;
 			blurBackgroundColor = this.isDarkTheme ? 0x303030 : 0xFFFFFF;
 		}
 		else if (!this.EnableTranslucency || (!isWindows10 && !isWindows11))
 		{
-			accent.AccentState = AccentState.ACCENT_DISABLED;
+			accent.AccentState = Win32.AccentState.ACCENT_DISABLED;
 			backgroundRect.Visibility = Visibility.Visible;
 			backgroundRect.Opacity = 1.0;
 			titlebarRect.Fill = new SolidColorBrush(Colors.Transparent);
@@ -233,7 +177,7 @@ public class ChromedWindow : Window
 		}
 		else if (isWindows11)
 		{
-			accent.AccentState = AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
+			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_ACRYLICBLURBEHIND;
 			blurOpacity = this.isDarkTheme ? 210 : 150;
 			blurBackgroundColor = this.isDarkTheme ? 0x202020 : 0xFFFFFF;
 
@@ -241,77 +185,27 @@ public class ChromedWindow : Window
 			titlebarRect.Fill = new SolidColorBrush(Colors.Transparent);
 			titlebarRect.Opacity = 1.0;
 
-			blurBehind.Enable = true;
+			enableBlurEffect = true;
+
+			// Set system-drawn backdrop type to Acrylic (Windows 11 Build 22621 and higher)
+			Win32.SetSystemBackdropType(windowHelper.Handle, Win32.DwmSystemBackdropType.DWMSBT_TRANSIENTWINDOW);
 		}
 		else if (isWindows10)
 		{
-			accent.AccentState = AccentState.ACCENT_ENABLE_BLURBEHIND;
+			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_BLURBEHIND;
 			blurOpacity = 255;
 			blurBackgroundColor = 0x000000;
 			backgroundRect.Visibility = Visibility.Visible;
 			backgroundRect.Opacity = 0.75;
 			titlebarRect.Fill = Application.Current.FindResource("MaterialDesignPaper") as SolidColorBrush;
 			titlebarRect.Opacity = 0.75;
-			blurBehind.Enable = true;
-		}
-
-		if (blurBehind.Enable)
-		{
-			blurBehind.RgnBlur = InvisibleRegion;
+			enableBlurEffect = true;
 		}
 
 		accent.GradientColor = ((uint)blurOpacity << 24) | ((uint)blurBackgroundColor & 0xFFFFFF);
-		int accentStructSize = Marshal.SizeOf(accent);
 
-		IntPtr accentPtr = Marshal.AllocHGlobal(accentStructSize);
-		Marshal.StructureToPtr(accent, accentPtr, false);
+		Win32.SetAccentPolicy(windowHelper.Handle, accent);
 
-		WindowCompositionAttributeData data = new();
-		data.Attribute = WindowCompositionAttribute.WCA_ACCENT_POLICY;
-		data.SizeOfData = accentStructSize;
-		data.Data = accentPtr;
-
-		SetWindowCompositionAttribute(windowHelper.Handle, ref data);
-
-		Marshal.FreeHGlobal(accentPtr);
-
-		accentPtr = Marshal.AllocHGlobal(sizeof(int));
-		Marshal.WriteInt32(accentPtr, this.isDarkTheme ? 1 : 0);
-
-		data.Attribute = WindowCompositionAttribute.WCA_USEDARKMODECOLORS;
-		data.SizeOfData = sizeof(int);
-		data.Data = accentPtr;
-
-		SetWindowCompositionAttribute(windowHelper.Handle, ref data);
-
-		Marshal.FreeHGlobal(accentPtr);
-
-		DwmEnableBlurBehindWindow(windowHelper.Handle, ref blurBehind);
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct AccentPolicy
-	{
-		public AccentState AccentState;
-		public uint AccentFlags;
-		public uint GradientColor;
-		public uint AnimationId;
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct WindowCompositionAttributeData
-	{
-		public WindowCompositionAttribute Attribute;
-		public IntPtr Data;
-		public int SizeOfData;
-	}
-
-	[StructLayout(LayoutKind.Sequential)]
-	private struct DWM_BLURBEHIND
-	{
-		public int Flags;
-		public bool Enable;
-		public IntPtr RgnBlur;
-		public bool TransitionOnMaximized;
+		Win32.SetBlurBehindWindow(windowHelper.Handle, enableBlurEffect);
 	}
 }

--- a/Windows/ChromedWindow.cs
+++ b/Windows/ChromedWindow.cs
@@ -197,12 +197,14 @@ public class ChromedWindow : Window
 		else if (isWindows10)
 		{
 			accent.AccentState = Win32.AccentState.ACCENT_ENABLE_BLURBEHIND;
-			blurOpacity = 255;
-			blurBackgroundColor = 0x000000;
-			backgroundRect.Visibility = Visibility.Visible;
-			backgroundRect.Opacity = 0.75;
-			titlebarRect.Fill = Application.Current.FindResource("MaterialDesignPaper") as SolidColorBrush;
-			titlebarRect.Opacity = 0.75;
+			accent.AccentFlags = 2;
+			blurOpacity = this.isDarkTheme ? 210 : 150;
+			blurBackgroundColor = this.isDarkTheme ? 0x202020 : 0xFFFFFF;
+
+			backgroundRect.Visibility = Visibility.Collapsed;
+			titlebarRect.Fill = new SolidColorBrush(Colors.Transparent);
+			titlebarRect.Opacity = 1.0;
+
 			enableBlurEffect = true;
 		}
 

--- a/XivToolsWpf.csproj
+++ b/XivToolsWpf.csproj
@@ -4,6 +4,7 @@
     <UseWPF>true</UseWPF>
     <AppendTargetFramework>False</AppendTargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
     <DocumentationFile>..\obj\XIVToolsWpf.xml</DocumentationFile>
     <NoWarn>1701;1702;SA1503;CS1591;SA1401;SA1516;CS0067;IDE0027;IDE0025;SA1011;SA1134;</NoWarn>


### PR DESCRIPTION
For visual comparisons, please refer to the main pull request.

**Changes:**
- Fixed caption (i.e., title bar) control buttons blending in with titlebar in Light mode.
- Fixed opaque title bar showing when window translucency is enabled on Windows 11.
- Made panel background dynamic depending on selected theme to improve UI clarity.
- Decreased titlebar area by 1px to remove horizontal black line.
- Moved Windows interop operations to a separate utils file called `Win32.cs`.
- Added immersive dark mode to adjust window frame based on Windows' system theme.
- Fixed slider rail mouse click behaviour when slider is in absolute mode. Now the slider's value will be determined based on the mouse cursor's position on the slider rail.
  - _Note: This behaviour was most noticeable on the window opacity slider._ 
- Fixed missing background on inactive non-opaque window.
- Fixed third party applications (e.g. Photoshop) wrongfully resetting Anamnesis' theme override.
- Added title bar invalidation to force redraw.