### PR TITLE
Resolved missing font family on dynamic IconBlock components

### DIFF
--- a/Styles/MenuStyles.xaml
+++ b/Styles/MenuStyles.xaml
@@ -48,7 +48,7 @@
 									
 									<!-- TODO -->
 									<Grid x:Name="IconWrapper" Visibility="Visible" Width="40">
-										<fa:IconBlock Icon="{Binding Icon}" Height="16" Width="16"/>
+										<fa:IconBlock FontFamily="/FontAwesome.Sharp;component/fonts/#Font Awesome 6 Free Solid" Icon="{Binding Icon}" Height="16" Width="16"/>
 									</Grid>
 									
 									<Grid x:Name="GlyphWrapper" Visibility="Collapsed" Width="40">


### PR DESCRIPTION
Aims to address https://github.com/imchillin/Anamnesis/issues/1571.

When treating icon property updates, it seems that FontAwesome.Sharp checks the font family, which when not explicitly set, might raise errors as the ones reported in the GitHub issue.