### PR TITLE
Updated info control component to support dynamic change of text keys

### DIFF
--- a/Controls/InfoControl.xaml
+++ b/Controls/InfoControl.xaml
@@ -51,7 +51,7 @@
 				VerticalAlignment="Center"
 				Foreground="{DynamicResource MaterialDesignBody}"
 				Grid.Column="1"
-				Margin="0, 4, 4, 4"
+				Margin="0, 0, 4, 4"
 				TextAlignment="Left"
 				TextWrapping="Wrap" />
 		</Grid>

--- a/Controls/InfoControl.xaml.cs
+++ b/Controls/InfoControl.xaml.cs
@@ -3,8 +3,9 @@
 
 namespace XivToolsWpf.Controls;
 
-using System.Windows.Controls;
 using PropertyChanged;
+using System.Windows.Controls;
+using XivToolsWpf.DependencyProperties;
 
 /// <summary>
 /// Interaction logic for InfoControl.xaml.
@@ -12,19 +13,24 @@ using PropertyChanged;
 [AddINotifyPropertyChangedInterface]
 public partial class InfoControl : UserControl
 {
+	public static readonly IBind<string?> KeyDp = Binder.Register<string?, InfoControl>(nameof(Key), OnKeyChanged, BindMode.OneWay);
+
 	public InfoControl()
 	{
 		this.InitializeComponent();
 
 		this.ContentArea.DataContext = this;
-
 		this.IsError = false;
 	}
 
 	public string? Key
 	{
-		get => this.TextBlock.Key;
-		set => this.TextBlock.Key = value;
+		get => KeyDp.Get(this);
+		set
+		{
+			KeyDp.Set(this, value);
+			this.TextBlock.Key = value;
+		}
 	}
 
 	public string? Text
@@ -33,9 +39,10 @@ public partial class InfoControl : UserControl
 		set => this.TextBlock.Text = value;
 	}
 
-	public bool IsError
+	public bool IsError { get; set; }
+
+	private static void OnKeyChanged(InfoControl sender, string? newValue)
 	{
-		get;
-		set;
+		sender.TextBlock.Key = newValue;
 	}
 }

--- a/Controls/TextBlock.xaml.cs
+++ b/Controls/TextBlock.xaml.cs
@@ -13,7 +13,7 @@ using XivToolsWpf.DependencyProperties;
 /// </summary>
 public partial class TextBlock : System.Windows.Controls.TextBlock
 {
-	public static readonly IBind<string> KeyDp = Binder.Register<string, TextBlock>(nameof(Key), OnKeyChanged, BindMode.OneWay);
+	public static readonly IBind<string?> KeyDp = Binder.Register<string?, TextBlock>(nameof(Key), OnKeyChanged, BindMode.OneWay);
 	public static readonly IBind<string?> ValueDp = Binder.Register<string?, TextBlock>(nameof(Value), OnValueChanged, BindMode.OneWay);
 	public static readonly IBind<bool> AllLanguagesDp = Binder.Register<bool, TextBlock>(nameof(AllLanguages), BindMode.OneWay);
 	private static ILocaleProvider? cachedlocaleProvider;
@@ -26,7 +26,11 @@ public partial class TextBlock : System.Windows.Controls.TextBlock
 		this.LoadString();
 	}
 
-	public string? Key { get; set; }
+	public string? Key
+	{
+		get => KeyDp.Get(this);
+		set => KeyDp.Set(this, value);
+	}
 
 	public string? Value
 	{
@@ -59,9 +63,8 @@ public partial class TextBlock : System.Windows.Controls.TextBlock
 		}
 	}
 
-	public static void OnKeyChanged(TextBlock sender, string val)
+	public static void OnKeyChanged(TextBlock sender, string? val)
 	{
-		sender.Key = val;
 		sender.LoadString();
 	}
 


### PR DESCRIPTION
Reopened pull request to target upstream.
Original: https://github.com/ergoxiv/AetherToolsWpf/pull/1.

---

I need this change to be able to update the info control text to explain to users why they can't change appearance and equipment based on the actor refresh availability.