### PR TITLE
Fixed issue with NumberBox causing application to crash due to overflow

### DIFF
--- a/Controls/NumberBox.xaml.cs
+++ b/Controls/NumberBox.xaml.cs
@@ -124,7 +124,7 @@ public partial class NumberBox : UserControl, INotifyPropertyChanged
 
 		set
 		{
-			this.Value = value - this.ValueOffset;
+			double v = value - this.ValueOffset;
 
 			if (!this.UncapTextInput)
 			{
@@ -132,16 +132,18 @@ public partial class NumberBox : UserControl, INotifyPropertyChanged
 				{
 					double range = this.Maximum - this.Minimum;
 
-					while (this.Value > this.Maximum)
-						this.Value -= range;
+					while (v > this.Maximum)
+						v -= range;
 
-					while (this.Value < this.Minimum)
-						this.Value += range;
+					while (v < this.Minimum)
+						v += range;
 				}
 
-				this.Value = Math.Max(this.Minimum, this.Value);
-				this.Value = Math.Min(this.Maximum, this.Value);
+				v = Math.Max(this.Minimum, v);
+				v = Math.Min(this.Maximum, v);
 			}
+
+			this.Value = v;
 		}
 	}
 


### PR DESCRIPTION
This pull request aims to address the following error, which is caused by writing the `Value` property without doing the boundary checks first:

```
2026-03-05 16:17:07.042 -06:00 [FTL] Value was either too large or too small for an unsigned byte.
System.OverflowException: Value was either too large or too small for an unsigned byte.
   at System.Convert.ThrowByteOverflowException()
   at System.Double.System.IConvertible.ToByte(IFormatProvider provider)
   at XivToolsWpf.Converters.NumberConverter.ConvertBack(Object value, Type targetType, Object parameter, CultureInfo culture)
   at System.Windows.Data.BindingExpression.ConvertProposedValue(Object value)
   at System.Windows.Data.BindingExpressionBase.UpdateValue()
   at System.Windows.Data.BindingExpressionBase.ProcessDirty()
   at System.Windows.Data.BindingExpressionBase.Dirty()
   at System.Windows.Data.BindingExpressionBase.SetValue(DependencyObject d, DependencyProperty dp, Object value)
   at System.Windows.DependencyObject.SetValueCommon(DependencyProperty dp, Object value, PropertyMetadata metadata, Boolean coerceWithDeferredReference, Boolean coerceWithCurrentValue, OperationType operationType, Boolean isInternal)
   at XivToolsWpf.DependencyProperties.DependencyProperty`1.Set(DependencyObject control, TValue value)
   at XivToolsWpf.Controls.NumberBox.set_Value(Double value)
   at XivToolsWpf.Controls.NumberBox.set_DisplayValue(Double value)
   at XivToolsWpf.Controls.NumberBox.TickValue(Boolean increase)
   at System.Windows.RoutedEventArgs.InvokeHandler(Delegate handler, Object target)
   at System.Windows.EventRoute.InvokeHandlersImpl(Object source, RoutedEventArgs args, Boolean reRaised)
   at System.Windows.UIElement.RaiseEventImpl(DependencyObject sender, RoutedEventArgs args)
   at System.Windows.UIElement.RaiseTrustedEvent(RoutedEventArgs args)
   at System.Windows.Input.InputManager.ProcessStagingArea()
   at System.Windows.Interop.HwndMouseInputProvider.ReportInput(IntPtr hwnd, InputMode mode, Int32 timestamp, RawMouseActions actions, Int32 x, Int32 y, Int32 wheel)
   at System.Windows.Interop.HwndMouseInputProvider.FilterMessage(IntPtr hwnd, WindowMessage msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Interop.HwndSource.InputFilterMessage(IntPtr hwnd, Int32 msg, IntPtr wParam, IntPtr lParam, Boolean& handled)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```